### PR TITLE
Resolve some cases of strongly-capturing 'self' to break retain cycles.

### DIFF
--- a/Feather/Sources/Database Packages/MPDatabasePackageController.m
+++ b/Feather/Sources/Database Packages/MPDatabasePackageController.m
@@ -235,9 +235,10 @@ NSString * const MPDatabasePackageControllerErrorDomain = @"MPDatabasePackageCon
         }
         
         if (requiresListener) {
+            __weak typeof(self) weakSelf = self;
             [self startListenerWithCompletionHandler:^(NSError *err)
             {
-                [self.notificationCenter postNotificationName:MPDatabasePackageListenerDidStartNotification object:self];
+                [weakSelf.notificationCenter postNotificationName:MPDatabasePackageListenerDidStartNotification object:self];
             }];
         }
         
@@ -1152,7 +1153,7 @@ static const NSUInteger MPDatabasePackageListenerMaxRetryCount = 30;
             e = nil;
             port += retries;
             
-            strongSelf.databaseListener = [[CBLListener alloc] initWithManager:_server port:port];
+            strongSelf.databaseListener = [[CBLListener alloc] initWithManager:strongSelf.server port:port];
             
             NSDictionary *txtDict = [strongSelf.databaseListener.TXTRecordDictionary mutableCopy];
             [txtDict setValue:@(port) forKey:@"port"];

--- a/Feather/Sources/Model Controllers/MPManagedObjectsController.m
+++ b/Feather/Sources/Model Controllers/MPManagedObjectsController.m
@@ -124,8 +124,9 @@ NSString * const MPManagedObjectsControllerLoadedBundledResourcesNotification = 
     SEL allObjectsForObjectSpecifierKeySel = NSSelectorFromString(allObjectsSpecifierKey);
 
     if (![self respondsToSelector:allObjectsForObjectSpecifierKeySel]) {
+        __weak typeof(self) weakSelf = self;
         id (^allObjectsForObjectSpecifierKey)(void) = ^id() {
-            return [self allObjects];
+            return [weakSelf allObjects];
         };
         
         //NSLog(@"Implementing '%@'", allObjectsSpecifierKey);


### PR DESCRIPTION
This PR:

- Addresses a few cases of strongly-capturing `self` inside blocks, which was causing causing somewhat large memory leaks when using instances of `MPManuscriptsPackageController` (depending on the compiler or import operations executed, several internal `CBLCaches` were initialised with 1MB capacity which were never released).