### PR TITLE
Add missing 'strongSelf' when weakly-capturing 'self' inside blocks

### DIFF
--- a/Feather/Sources/Database Packages/MPDatabasePackageController.m
+++ b/Feather/Sources/Database Packages/MPDatabasePackageController.m
@@ -238,7 +238,8 @@ NSString * const MPDatabasePackageControllerErrorDomain = @"MPDatabasePackageCon
             __weak typeof(self) weakSelf = self;
             [self startListenerWithCompletionHandler:^(NSError *err)
             {
-                [weakSelf.notificationCenter postNotificationName:MPDatabasePackageListenerDidStartNotification object:self];
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf.notificationCenter postNotificationName:MPDatabasePackageListenerDidStartNotification object:self];
             }];
         }
         

--- a/Feather/Sources/Model Controllers/MPManagedObjectsController.m
+++ b/Feather/Sources/Model Controllers/MPManagedObjectsController.m
@@ -126,7 +126,8 @@ NSString * const MPManagedObjectsControllerLoadedBundledResourcesNotification = 
     if (![self respondsToSelector:allObjectsForObjectSpecifierKeySel]) {
         __weak typeof(self) weakSelf = self;
         id (^allObjectsForObjectSpecifierKey)(void) = ^id() {
-            return [weakSelf allObjects];
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            return [strongSelf allObjects];
         };
         
         //NSLog(@"Implementing '%@'", allObjectsSpecifierKey);


### PR DESCRIPTION
This PR: 

- Adds 'strongSelf' variable inside the blocks to ensure the execution completes even if 'self' gets deallocated during execution. (follow-on fix from #9)