### PR TITLE
Add 'stringByReplacingHTMLNamedEntitiesWithNumericEntities' NSString category method 

### DIFF
--- a/FeatherAppKitExtensions/NSXMLElement+MPExtensions.h
+++ b/FeatherAppKitExtensions/NSXMLElement+MPExtensions.h
@@ -270,6 +270,9 @@ typedef BOOL (^MPXMLNodeVisitor)(NSXMLNode *__nonnull node);
 /** Replace all solo ampersands (& characters) that aren't already part of either `&amp;`, `&quot;`, `&apos;`, `&lt;`, or `&gt;`, with `&amp;`.*/
 - (nonnull NSString *)stringByEscapingUnescapedAmpersands;
 
+/** Replace all HTML named entities (e.g. @c &nbsp;) with their numeric entity equivalents. */
+- (nonnull NSString *)stringByReplacingHTMLNamedEntitiesWithNumericEntities;
+
 /**
  
  Replace the characters &, ", ', < and > with their XML entity values:

--- a/FeatherAppKitExtensions/NSXMLElement+MPExtensions.m
+++ b/FeatherAppKitExtensions/NSXMLElement+MPExtensions.m
@@ -1936,6 +1936,26 @@ typedef NS_ENUM(NSInteger, MPXMLElementErrorCode) {
     return s;
 }
 
+- (NSString *)stringByReplacingHTMLNamedEntitiesWithNumericEntities
+{
+    // Return early with the unmodified receiver if it doesn't contain any '&' characters
+    if ([self rangeOfString:@"&"].location == NSNotFound) {
+        return self;
+    }
+
+    __block NSString *s = nil;
+    // A map of named entities and their numeric entity equivalents
+    NSDictionary *entitiesToReplace = @{@"&nbsp;": @"&#xA0;",
+                                        };
+
+    // Replace all named entities in `entitiesToReplace` with their numeric entity equivalents
+    [entitiesToReplace enumerateKeysAndObjectsUsingBlock:^(NSString *namedEntity, NSString *numericEntity, BOOL *stop) {
+        s = [self stringByReplacingOccurrencesOfString:namedEntity withString:numericEntity];
+    }];
+
+    return s;
+}
+
 - (BOOL)appearsToContainSerialisedXML
 {
     if (self.length > 1 && (([self containsString:@"<"]  && [self containsString:@">"]) || ([self containsString:@"&"] && [self containsString:@";"]))) {


### PR DESCRIPTION
This is useful for replacing HTML named entities (e.g. `&nbsp;`) with their numeric entity equivalents (e.g. `&#xA0;`).

For now, this method will only replace non-breaking space entities, but other characters can easily be added via the `NSDictionary` internal to the method.