### PR TITLE
Adds 'ifExists:' subscript extension method for indexable 'Collection's

### DIFF
--- a/FeatherExtensions/CollectionType+MPExtensions.swift
+++ b/FeatherExtensions/CollectionType+MPExtensions.swift
@@ -7,18 +7,7 @@
 //
 
 public extension Collection {
-    
-    /*
-    public func first(predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.Iterator.Element? {
-        for e in self {
-            if try predicate(e) {
-                return e
-            }
-        }
-        return nil
-    }*/
-    
-    
+
     func chunks(withDistance distance: IndexDistance) -> [[SubSequence.Iterator.Element]] {
         var index = startIndex
         let iterator: AnyIterator<Array<SubSequence.Iterator.Element>> = AnyIterator {
@@ -32,4 +21,15 @@ public extension Collection {
         return Array(iterator)
     }
     
+}
+
+extension Collection where Indices.Iterator.Element == Index {
+
+    /// Safely subscript a `Collection`. Returns either the object at the given index, or `nil` if the index would
+    /// otherwise cause an out-of-bounds exception.
+    ///
+    /// - Parameter index: The integer index of the object in the `Collection` to return.
+    subscript (ifExists index: Index) -> Iterator.Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
 }


### PR DESCRIPTION
Allows an object in a `Collection` to be safely accessed via index subscripting. This returns the object as an Optional at the given index, or `nil` if the subscript operation would otherwise result in an out-of-bounds exception with the default subscript method.

**NOTES**
- Also removes an extension method that was already commented-out (as it now exists in the standard library).